### PR TITLE
Buildissues osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ FASTFLAGS = -O3
 COMPILEFLAGS =$(DEBUGFLAGS) $(FASTFLAGS)
 OFILES = $(OBJECTS:%=%.o)
 CCC	= g++
-IFLAGS = -I.
-LFLAGS =
+IFLAGS = -I. `pkg-config --cflags-only-I ncurses`
+LFLAGS = `pkg-config --libs-only-L ncurses`
 LIBS	= -lform -lmenu -lpanel -lncurses
 
 all	: $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,18 @@ FASTFLAGS = -O3
 COMPILEFLAGS =$(DEBUGFLAGS) $(FASTFLAGS)
 OFILES = $(OBJECTS:%=%.o)
 CCC	= g++
-IFLAGS = -I. `pkg-config --cflags-only-I ncurses`
-LFLAGS = `pkg-config --libs-only-L ncurses`
+IFLAGS = -I.
+LFLAGS =
 LIBS	= -lform -lmenu -lpanel -lncurses
+
+PROPER_PKG_CONFIG = $(shell pkg-config --cflags ncurses >/dev/null 2>&1 && echo true || echo false)
+$(info $$PROPER_PKG_CONFIG is [${PROPER_PKG_CONFIG}])
+
+ifeq ($(PROPER_PKG_CONFIG),true)
+IFLAGS += $(shell pkg-config --cflags-only-I ncurses)
+LFLAGS += $(shell pkg-config --libs-only-L ncurses)
+endif
+$(info $$IFLAGS is [${IFLAGS}])
 
 all	: $(EXECUTABLE)
 


### PR DESCRIPTION
reworked Makefile to link against pkg-config provided paths for lib and include (should make doneyet more portable)
part of fixing #35 