### PR TITLE
Avoid close with q, use CTRL q instead

### DIFF
--- a/workspace.cc
+++ b/workspace.cc
@@ -211,7 +211,7 @@ void Workspace::Run() {
       case 27:  // Escape
         list_->SelectNoItem();
         break;
-      case 'q':
+      case CTRL('q'):
         Quit();
         break;
     }

--- a/workspace.h
+++ b/workspace.h
@@ -46,6 +46,10 @@ using std::vector;
   "* h - Shows and closes this help dialog.\n"                               \
   "* q - Quit.\n"
 
+#ifndef CTRL
+#define CTRL(c) ((c) & 037)
+#endif
+
 class StringListItem : public ListItem {
  public:
   explicit StringListItem(string str) : ListItem() { str_ = str; }


### PR DESCRIPTION
This PR suggests avoid closing the application only by pressing `q`. 
Instead, use `Ctrl q` to prevent closing accidentally.